### PR TITLE
Stage clang-format and finalize build config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+---
+Language: Cpp
+AllowShortCaseLabelsOnASingleLine: true
+---

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -15,7 +15,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install linters
         run: |
           sudo apt-get update
@@ -32,7 +32,7 @@ jobs:
         shell: bash
     steps:
      - name: Checkout
-       uses: actions/checkout@v3
+       uses: actions/checkout@v4
      - name: Install dependencies
        run: |
          sudo apt-get update

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -42,6 +42,7 @@ jobs:
          wget https://raw.githubusercontent.com/Kitware/VTK/master/CMake/FindNetCDF.cmake -P cmake
      - name: Build
        run: |
+         cmake . -DCMAKE_BUILD_TYPE=Release
          make
      - name: Run tests
        run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,9 +13,9 @@ repos:
     - id: end-of-file-fixer
       exclude: benchmarking
 
-  - repo: https://github.com/pocc/pre-commit-hooks
-    rev: v1.3.5
-    hooks:
+#  - repo: https://github.com/pocc/pre-commit-hooks
+#    rev: v1.3.5
+#    hooks:
 #      - id: clang-format
 #        args: [--style=Google]
 #      - id: clang-tidy
@@ -23,7 +23,7 @@ repos:
 #      - id: uncrustify
 #      - id: cppcheck
 #      - id: cpplint
-      - id: include-what-you-use
+#      - id: include-what-you-use
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.27.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
 #    rev: v1.3.5
 #    hooks:
 #      - id: clang-format
-#        args: [--style=Google]
+#        args: [ '-style=file' ]
 #      - id: clang-tidy
 #      - id: oclint
 #      - id: uncrustify
@@ -43,5 +43,5 @@ ci:
   autoupdate_branch: ''
   autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
   autoupdate_schedule: quarterly
-  skip: [ include-what-you-use ]
+  skip: [] # [ include-what-you-use ]
   submodules: false


### PR DESCRIPTION
<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [ ] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #xyz
- [x] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

 * Stages a `clang-format` configuration for setting the coding style.
 * Finalizes the configuration needed for running `cmake`-based builds with NetCDF support (Should we also enable builds without NetCDF?).
 * Disables the `include-what-you-use` pre-commit hook.

### Does this PR introduce a breaking change?
<!-- If so, please describe the impact and migration path for existing applications -->

No.

### Other information:

@analytophile I'm not sure what rule set you apply when coding C++ (`IndentWidth: 2`?). If you want to add any existing rules into the formatter, please feel free.

Would you open to enabling GitHub Actions here for CI support? This would ensure that commits on the main branch and any pull requests opened against the main branch are able to be built. 