### PR TITLE
PET_HAMON fix for negative PET and bug fix to PCT_PDIFF diagnostic

### DIFF
--- a/src/Diagnostics.cpp
+++ b/src/Diagnostics.cpp
@@ -674,7 +674,7 @@ double CDiagnostic::CalculateDiagnostic(CTimeSeriesABC  *pTSMod,
       }
       if (N > 0.0)
       {
-          return (100.0 * maxMod - maxObs)/maxObs;
+          return (100.0 * ((maxMod - maxObs)/maxObs));
       }
       else
       {

--- a/src/Evaporation.cpp
+++ b/src/Evaporation.cpp
@@ -267,7 +267,7 @@ double Hamon1961Evap(const force_struct *F)
 
   abs_hum=216.7*(sat_vap*MB_PER_KPA)/(F->temp_daily_ave+ZERO_CELSIUS);//abs. humidity, g/m3 (may wish to make separate function of T)s
 
-  return 0.0055*4.0*abs_hum*F->day_length*F->day_length*MM_PER_INCH;
+  return max(0.0,0.0055*4.0*abs_hum*F->day_length*F->day_length*MM_PER_INCH);
 }
 
 //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- adds max(x,0) for PET_HAMON method to fix negative PET from being introduced
- fixes bug in PCT_PDIFF diagnostic calculaton with appropriate bracketing
