### PR TITLE
Add filters to compress (deflate) and chunk standard and custom netCDF outputs

### DIFF
--- a/src/CustomOutput.cpp
+++ b/src/CustomOutput.cpp
@@ -689,7 +689,7 @@ void CCustomOutput::WriteNetCDFFileHeader(const optStruct &Options)
     retval = nc_def_var_deflate(_netcdf_ID, varid_data, 1, 1, NETCDF_DEFLATE_LEVEL); HandleNetCDFErrors(retval);
 
     // Set chunksizes for data variable (time, ndata)
-    chunksize2[1] = max((size_t)1, min(_nData, (size_t)(NETCDF_CHUNKSIZE_MB * 1024 * 1024 / sizeof(double) / chunksize2[0]))); // Ensure at least one basin per chunk
+    chunksize2[1] = max((size_t)1, min((size_t)_nData, (size_t)(NETCDF_CHUNKSIZE_MB * 1024 * 1024 / sizeof(double) / chunksize2[0]))); // Ensure at least one basin per chunk
     retval = nc_def_var_chunking(_netcdf_ID, varid_data, NC_CHUNKED, chunksize2); HandleNetCDFErrors(retval);
 
     //(f) set some attributes to variable _netCDFtag

--- a/src/CustomOutput.cpp
+++ b/src/CustomOutput.cpp
@@ -217,7 +217,49 @@ void CCustomOutput::SetHistogramParams(const double minv,const double maxv, cons
   _hist_max=maxv;
   _nBins=numBins;
 }
+//////////////////////////////////////////////////////////////////
+/// \brief Compute the approximate number of time steps for the output array. This is not meant to be exact. Do not allocate memory based on this value.
+/// \param Options [in] Global model options information
+/// \return Number of time steps (int)
+int CCustomOutput::ApproximateNumTimeSteps(const optStruct &Options) const
+{
+  int nsteps = 0;  // return value
+  time_struct start, end;
 
+  JulianConvert(0, Options.julian_start_day, Options.julian_start_year, Options.calendar, start);
+  JulianConvert(Options.duration, Options.julian_start_day, Options.julian_start_year, Options.calendar, end);
+
+  switch(_timeAgg) {
+    case YEARLY:
+      nsteps = int(end.year - start.year);
+      break;
+    case WATER_YEARLY:
+    // wateryr_mo: Starting month of the water year
+      nsteps = int(end.year - start.year);
+      if ((start.month < end.month) && (start.month < Options.wateryr_mo) && (end.month >= Options.wateryr_mo)) nsteps++;
+      if ((start.month > end.month) && (start.month >= Options.wateryr_mo) && (end.month < Options.wateryr_mo)) nsteps--;
+      break;
+    case MONTHLY:
+      nsteps = int((end.year - start.year) * 12 + (end.month - start.month));
+      break;
+    case DAILY:
+      nsteps = int(ceil(Options.duration));
+      break;
+    case EVERY_NDAYS:
+      nsteps = int(ceil(Options.duration / Options.custom_interval));
+      break;
+    case EVERY_TSTEP:
+      nsteps = int(ceil(Options.duration / Options.timestep));
+      break;
+    case ENTIRE_SIM:
+      nsteps = 1;
+      break;
+    default:
+      nsteps = 0;
+      break;
+  }
+  return max(0, nsteps); // Ensure non-negative and account for partial time step at end of simulation
+}
 ///////////////////////////////////////////////////////////////////
 /// \brief Allocates memory and initialize data storage of a CCustomOutput object
 /// \remarks Called prior to simulation. Determines size of and allocates memory for (member) data[][] array needed in statistical calculations
@@ -554,6 +596,7 @@ void CCustomOutput::WriteNetCDFFileHeader(const optStruct &Options)
 
   int         retval;                                // error value for NetCDF routines
   size_t      start[1], count[1];                    // determines where and how much will be written to NetCDF
+  size_t      chunksize2[2];                          // Chunksize (time, data)
   string      tmp,tmp2,tmp3,tmp4;
 
   bool cant_support=(_aggstat==AGG_RANGE || _aggstat==AGG_95CI || _aggstat==AGG_QUARTILES || _aggstat==AGG_HISTOGRAM);
@@ -574,11 +617,20 @@ void CCustomOutput::WriteNetCDFFileHeader(const optStruct &Options)
   // time
   // ----------------------------------------------------------
   // (a) Define the DIMENSIONS. NetCDF will hand back an ID for each.
+
   retval = nc_def_dim(_netcdf_ID, "time", NC_UNLIMITED, &time_dimid);              HandleNetCDFErrors(retval);
 
   // (b) Define the time variable.
   dimids1[0] = time_dimid;
   retval = nc_def_var(_netcdf_ID, "time", NC_DOUBLE, ndims1,dimids1, &varid_time); HandleNetCDFErrors(retval);
+
+  // Enable deflate compression for time variable (shuffle, zlib, deflate_level)
+  retval = nc_def_var_deflate(_netcdf_ID, varid_time, 1, 1, NETCDF_DEFLATE_LEVEL); HandleNetCDFErrors(retval);
+
+  // Set chunksize to len(time)
+  chunksize2[0] = ApproximateNumTimeSteps(Options) + 1;
+  retval = nc_def_var_chunking(_netcdf_ID, varid_time, NC_CHUNKED, &chunksize2[0]); HandleNetCDFErrors(retval);
+
 
   // (c) Assign units attributes to the netCDF VARIABLES.
   //     --> converts start day into "hours since YYYY-MM-DD HH:MM:SS"
@@ -632,6 +684,13 @@ void CCustomOutput::WriteNetCDFFileHeader(const optStruct &Options)
     dimids2[0] = time_dimid;
     dimids2[1] = ndata_dimid;
     retval = nc_def_var(_netcdf_ID, netCDFtag.c_str(), NC_DOUBLE, ndims2, dimids2, &varid_data);    HandleNetCDFErrors(retval);
+
+    // Enable deflate compression for data variable
+    retval = nc_def_var_deflate(_netcdf_ID, varid_data, 1, 1, NETCDF_DEFLATE_LEVEL); HandleNetCDFErrors(retval);
+
+    // Set chunksizes for data variable (time, ndata)
+    chunksize2[1] = max((size_t)1, min(_nData, (size_t)(NETCDF_CHUNKSIZE_MB * 1024 * 1024 / sizeof(double) / chunksize2[0]))); // Ensure at least one basin per chunk
+    retval = nc_def_var_chunking(_netcdf_ID, varid_data, NC_CHUNKED, chunksize2); HandleNetCDFErrors(retval);
 
     //(f) set some attributes to variable _netCDFtag
     tmp=_timeAggStr+" "+_statStr+" "+_varName+" "+_spaceAggStr;

--- a/src/CustomOutput.h
+++ b/src/CustomOutput.h
@@ -126,7 +126,10 @@ public:/*------------------------------------------------------*/
 
   void        SetHistogramParams(const double min,const double max, const int numBins);
 
+  int         ApproximateNumTimeSteps(const optStruct &Options) const;
+
   spatial_agg GetSpatialAgg() const;
+
   void        InitializeCustomOutput(const optStruct &Options);
 
   void        WriteFileHeader  (const optStruct &Options);

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,6 +15,7 @@
 #            Feb 2025    James Craig and Bohao Tang - support for new Mac (Applie Silicon)
 ###
 # appname := raven_rev$(shell svnversion -n . | sed -e 's/:/-/g')_$(shell uname -o).exe
+# To debug, add -g to CXXFLAGS and LDFLAGS
 appname := Raven.exe
 
 CXX      := g++

--- a/src/ModelInitialize.cpp
+++ b/src/ModelInitialize.cpp
@@ -70,6 +70,7 @@ void CModel::Initialize(const optStruct &Options)
       }
     }
   }
+
   // reserve memory for mass balance arrays
   //--------------------------------------------------------------
   _aCumulativeBal = new double * [_nHydroUnits];

--- a/src/ParseInput.cpp
+++ b/src/ParseInput.cpp
@@ -1445,6 +1445,9 @@ bool ParseMainInputFile (CModel     *&pModel,
       if(Options.noisy) { cout <<"Output File Interval"<<endl; }
       if(Len<2) { ImproperFormatWarning(":OutputInterval",p,Options.noisy);  break; }
       Options.output_interval = s_to_d(s[1]);
+      if (Options.output_interval <= 0) {
+        ExitGracefully("ParseInput :OutputInterval: Output interval must be greater than 0",BAD_DATA_WARN);
+      }
       break;
     }
     case(53):  //--------------------------------------------

--- a/src/ParseInput.cpp
+++ b/src/ParseInput.cpp
@@ -3730,6 +3730,12 @@ bool ParseMainInputFile (CModel     *&pModel,
   ExitGracefullyIf(Options.duration<0,
                    "ParseMainInputFile::Model duration less than zero. Make sure :EndDate is after :StartDate.",BAD_DATA_WARN);
 
+  // Compute the size of the output's time dimension
+  Options.n_out_time = (int)(floor(ceil((Options.duration + TIME_CORRECTION)/Options.timestep))/Options.output_interval);
+  if (Options.n_out_time==0) {
+    WriteAdvisory("ParseMainInputFile::Number of output time steps is zero. Check :Duration, :Timestep, and :OutputInterval commands.",BAD_DATA);
+  }
+
   if((Options.nNetCDFattribs>0) && (Options.output_format!=OUTPUT_NETCDF)){
     WriteAdvisory("ParseMainInputFile: NetCDF attributes were specified but output format is not NetCDF.",Options.noisy);
   }

--- a/src/RavenInclude.h
+++ b/src/RavenInclude.h
@@ -251,6 +251,8 @@ const double  USE_TEMPLATE_VALUE      =-55555.5;                                
 const double  NOT_NEEDED              =-66666.6;                                ///< arbitrary value indicating that a non-auto parameter is not needed for the current model configuration
 const double  NOT_NEEDED_AUTO         =-77777.7;                                ///< arbitrary value indicating that a autogeneratable parameter is not needed for the current model configuration
 const double  NETCDF_BLANK_VALUE      =-9999.0;                                 ///< NetCDF flag for blank value
+const int     NETCDF_DEFLATE_LEVEL    = 6;                                      ///< NetCDF deflate level (compression 1-9)
+const int     NETCDF_CHUNKSIZE_MB     = 10;                                     ///< NetCDF chunk size in MB (must be >1 for compression to work)
 const double  RAV_BLANK_DATA          =-1.2345;                                 ///< double corresponding to blank/void data item (also used in input files)
 const double  DIRICHLET_TEMP          =-9999.0;                                 ///< dirichlet concentration flag corresponding to air temperature
 const int     FROM_STATION_VAR        =-55;                                     ///< special flag indicating that NetCDF indices should be looked up from station attribute table
@@ -1067,6 +1069,7 @@ struct optStruct
   double           convergence_crit;          ///< convergence criteria
   double           max_iterations;            ///< maximum number of iterations for iterative solver method
   double           timestep;                  ///< numerical method timestep (in days)
+  size_t           n_out_time;                ///< size of output time dimension
   double           output_interval;           ///< write to output file every x number of timesteps
   ensemble_type    ensemble;                  ///< ensemble type (or ENSEMBLE_NONE if single model)
   string           external_script;           ///< call to external script/.exe once per timestep (or "" if none)

--- a/src/StandardOutput.cpp
+++ b/src/StandardOutput.cpp
@@ -2021,6 +2021,7 @@ void CModel::WriteNetcdfStandardHeaders(const optStruct &Options)
   string      tmpFilename;
   int         p;                                     // loop over all sub-basins
   string      tmp,tmp2,tmp3;
+  size_t      chunksize_time;                        // Size of output time dimension
 
   // initialize all potential file IDs with -9 == "not existing and hence not opened"
   _HYDRO_ncid    = -9;   // output file ID for Hydrographs.nc         (-9 --> not opened)
@@ -2059,7 +2060,14 @@ void CModel::WriteNetcdfStandardHeaders(const optStruct &Options)
 
   /// Define the time variable. Assign units attributes to the netCDF VARIABLES.
   dimids1[0] = time_dimid;
+  // Set chunksize to the number of time steps
+  chunksize_time = Options.n_out_time;
+
   retval = nc_def_var(_HYDRO_ncid, "time", NC_DOUBLE, ndims1,dimids1, &varid_time); HandleNetCDFErrors(retval);
+  // Enable compression and chunking
+  retval = nc_def_var_deflate(_HYDRO_ncid, varid_time, 1, 1, NETCDF_DEFLATE_LEVEL); HandleNetCDFErrors(retval);
+  retval = nc_def_var_chunking(_HYDRO_ncid, varid_time, NC_CHUNKED, &chunksize_time); HandleNetCDFErrors(retval);
+
   retval = nc_put_att_text(_HYDRO_ncid, varid_time, "units"   ,      strlen(starttime)  , starttime);   HandleNetCDFErrors(retval);
   retval = nc_put_att_text(_HYDRO_ncid, varid_time, "calendar",      strlen("gregorian"), "gregorian"); HandleNetCDFErrors(retval);
   retval = nc_put_att_text(_HYDRO_ncid, varid_time, "standard_name", strlen("time"),      "time");      HandleNetCDFErrors(retval);
@@ -2081,7 +2089,7 @@ void CModel::WriteNetcdfStandardHeaders(const optStruct &Options)
     // (b) create dimension "nbasins"
     retval = nc_def_dim(_HYDRO_ncid, "nbasins", nSim, &nbasins_dimid);                             HandleNetCDFErrors(retval);
 
-    // (c) create variable  and set attributes for"basin_name"
+    // (c) create variable  and set attributes for "basin_name"
     dimids1[0] = nbasins_dimid;
     retval = nc_def_var(_HYDRO_ncid, "basin_name", NC_STRING, ndims1, dimids1, &varid_bsim);       HandleNetCDFErrors(retval);
     tmp ="ID of sub-basins with simulated outflows";
@@ -2146,6 +2154,10 @@ void CModel::WriteNetcdfStandardHeaders(const optStruct &Options)
     /// Define the time variable. Assign units attributes to the netCDF VARIABLES.
     dimids1[0] = time_dimid;
     retval = nc_def_var     (_RESSTAGE_ncid,"time",NC_DOUBLE,ndims1,dimids1,&varid_time);           HandleNetCDFErrors(retval);
+    // Enable compression and chunking
+    retval = nc_def_var_deflate(_RESSTAGE_ncid, varid_time, 1, 1, NETCDF_DEFLATE_LEVEL); HandleNetCDFErrors(retval);
+    retval = nc_def_var_chunking(_RESSTAGE_ncid, varid_time, NC_CHUNKED, &chunksize_time); HandleNetCDFErrors(retval);
+
     retval = nc_put_att_text(_RESSTAGE_ncid,varid_time,"units",strlen(starttime),starttime);        HandleNetCDFErrors(retval);
     retval = nc_put_att_text(_RESSTAGE_ncid,varid_time,"calendar",strlen("gregorian"),"gregorian"); HandleNetCDFErrors(retval);
     retval = nc_put_att_text(_RESSTAGE_ncid,varid_time,"standard_name",strlen("time"),"time");      HandleNetCDFErrors(retval);
@@ -2225,9 +2237,13 @@ void CModel::WriteNetcdfStandardHeaders(const optStruct &Options)
     // Define the DIMENSIONS. NetCDF will hand back an ID
     retval = nc_def_dim(_STORAGE_ncid, "time", NC_UNLIMITED, &time_dimid);  HandleNetCDFErrors(retval);
 
-    /// Define the time variable.
+     /// Define the time variable.
     dimids1[0] = time_dimid;
     retval = nc_def_var(_STORAGE_ncid, "time", NC_DOUBLE, ndims1,dimids1, &varid_time); HandleNetCDFErrors(retval);
+    // Enable compression and chunking
+    retval = nc_def_var_deflate(_STORAGE_ncid, varid_time, 1, 1, NETCDF_DEFLATE_LEVEL); HandleNetCDFErrors(retval);
+    retval = nc_def_var_chunking(_STORAGE_ncid, varid_time, NC_CHUNKED, &chunksize_time); HandleNetCDFErrors(retval);
+
     retval = nc_put_att_text(_STORAGE_ncid, varid_time, "units"   , strlen(starttime)  , starttime);   HandleNetCDFErrors(retval);
     retval = nc_put_att_text(_STORAGE_ncid, varid_time, "calendar", strlen("gregorian"), "gregorian"); HandleNetCDFErrors(retval);
 
@@ -2274,8 +2290,13 @@ void CModel::WriteNetcdfStandardHeaders(const optStruct &Options)
     // time vector
     // ----------------------------------------------------------
     retval = nc_def_dim(_FORCINGS_ncid,"time",NC_UNLIMITED,&time_dimid);  HandleNetCDFErrors(retval);
+
     dimids1[0] = time_dimid;
     retval = nc_def_var(_FORCINGS_ncid,"time",NC_DOUBLE,ndims1,dimids1,&varid_time); HandleNetCDFErrors(retval);
+    // Enable compression and chunking
+    retval = nc_def_var_deflate(_FORCINGS_ncid, varid_time, 1, 1, NETCDF_DEFLATE_LEVEL); HandleNetCDFErrors(retval);
+    retval = nc_def_var_chunking(_FORCINGS_ncid, varid_time, NC_CHUNKED, &chunksize_time); HandleNetCDFErrors(retval);
+
     retval = nc_put_att_text(_FORCINGS_ncid,varid_time,"units",strlen(starttime),starttime);   HandleNetCDFErrors(retval);
     retval = nc_put_att_text(_FORCINGS_ncid,varid_time,"calendar",strlen("gregorian"),"gregorian"); HandleNetCDFErrors(retval);
 
@@ -2322,8 +2343,15 @@ void CModel::WriteNetcdfStandardHeaders(const optStruct &Options)
     // time vector
     // ----------------------------------------------------------
     retval = nc_def_dim(_RESMB_ncid,"time",NC_UNLIMITED,&time_dimid);  HandleNetCDFErrors(retval);
+
+
     dimids1[0] = time_dimid;
     retval = nc_def_var(_RESMB_ncid,"time",NC_DOUBLE,ndims1,dimids1,&varid_time);                HandleNetCDFErrors(retval);
+
+     // Enable compression and chunking
+    retval = nc_def_var_deflate(_RESMB_ncid, varid_time, 1, 1, NETCDF_DEFLATE_LEVEL); HandleNetCDFErrors(retval);
+    retval = nc_def_var_chunking(_RESMB_ncid, varid_time, NC_CHUNKED, &chunksize_time); HandleNetCDFErrors(retval);
+
     retval = nc_put_att_text(_RESMB_ncid,varid_time,"units",strlen(starttime),starttime);        HandleNetCDFErrors(retval);
     retval = nc_put_att_text(_RESMB_ncid,varid_time,"calendar",strlen("gregorian"),"gregorian"); HandleNetCDFErrors(retval);
 
@@ -3018,12 +3046,20 @@ int NetCDFAddMetadata(const int fileid,const int time_dimid,string shortname,str
   int retval;
   int dimids[1];
   dimids[0] = time_dimid;
+  size_t chunksize[1];
 
   static double fill_val[] = {NETCDF_BLANK_VALUE};
   static double miss_val[] = {NETCDF_BLANK_VALUE};
 
   // (a) create variable precipitation
   retval = nc_def_var(fileid,shortname.c_str(),NC_DOUBLE,1,dimids,&varid); HandleNetCDFErrors(retval);
+
+  // Set compression
+  retval = nc_def_var_deflate(fileid, varid, 1, 1, NETCDF_DEFLATE_LEVEL); HandleNetCDFErrors(retval);
+  // Get the chunksize of the time dimension
+  retval = nc_inq_var_chunking(fileid, time_dimid, NULL, &chunksize[0]); HandleNetCDFErrors(retval);
+  // Set chunksize to number of time steps, or 1 if time dimension is unlimited
+  retval = nc_def_var_chunking(fileid, varid, NC_CHUNKED, chunksize); HandleNetCDFErrors(retval);
 
   // (b) add attributes to variable
   retval = nc_put_att_text  (fileid,varid,"units",units.length(),units.c_str());              HandleNetCDFErrors(retval);
@@ -3049,6 +3085,7 @@ int NetCDFAddMetadata2D(const int fileid,const int time_dimid,int nbasins_dimid,
   int    retval;
   int    dimids2[2];
   string tmp;
+  size_t chunksize2[2];
 
   static double fill_val[] = {NETCDF_BLANK_VALUE};
   static double miss_val[] = {NETCDF_BLANK_VALUE};
@@ -3058,6 +3095,17 @@ int NetCDFAddMetadata2D(const int fileid,const int time_dimid,int nbasins_dimid,
 
   // (a) create variable
   retval = nc_def_var(fileid,shortname.c_str(),NC_DOUBLE,2,dimids2,&varid); HandleNetCDFErrors(retval);
+  // Set compression
+  retval = nc_def_var_deflate(fileid, varid, 1, 1, NETCDF_DEFLATE_LEVEL); HandleNetCDFErrors(retval);
+  // Set time chunksize to number of time steps
+  retval = nc_inq_var_chunking(fileid, time_dimid, NULL, &chunksize2[0]); HandleNetCDFErrors(retval);
+   // Set nbasins chunksize to number ensuring that chunks have approximately 10 MB of data (assuming double precision)
+  retval = nc_inq_dimlen(fileid, nbasins_dimid, &chunksize2[1]); HandleNetCDFErrors(retval);
+
+
+  chunksize2[1] = max((size_t)1, min(chunksize2[1], (size_t)(NETCDF_CHUNKSIZE_MB * 1024 * 1024 / sizeof(double) / chunksize2[0]))); // Ensure at least one basin per chunk
+  // Set chunksize
+  retval = nc_def_var_chunking(fileid, varid, NC_CHUNKED, chunksize2); HandleNetCDFErrors(retval);
 
   tmp = "basin_name";
 

--- a/src/StandardOutput.cpp
+++ b/src/StandardOutput.cpp
@@ -2061,7 +2061,7 @@ void CModel::WriteNetcdfStandardHeaders(const optStruct &Options)
   /// Define the time variable. Assign units attributes to the netCDF VARIABLES.
   dimids1[0] = time_dimid;
   // Set chunksize to the number of time steps
-  chunksize_time = Options.n_out_time;
+  chunksize_time = max(1, Options.n_out_time);
 
   retval = nc_def_var(_HYDRO_ncid, "time", NC_DOUBLE, ndims1,dimids1, &varid_time); HandleNetCDFErrors(retval);
   // Enable compression and chunking
@@ -3046,6 +3046,7 @@ int NetCDFAddMetadata(const int fileid,const int time_dimid,string shortname,str
   int retval;
   int dimids[1];
   dimids[0] = time_dimid;
+  int    time_varid;
   size_t chunksize[1];
 
   static double fill_val[] = {NETCDF_BLANK_VALUE};
@@ -3053,12 +3054,11 @@ int NetCDFAddMetadata(const int fileid,const int time_dimid,string shortname,str
 
   // (a) create variable precipitation
   retval = nc_def_var(fileid,shortname.c_str(),NC_DOUBLE,1,dimids,&varid); HandleNetCDFErrors(retval);
-
   // Set compression
   retval = nc_def_var_deflate(fileid, varid, 1, 1, NETCDF_DEFLATE_LEVEL); HandleNetCDFErrors(retval);
-  // Get the chunksize of the time dimension
-  retval = nc_inq_var_chunking(fileid, time_dimid, NULL, &chunksize[0]); HandleNetCDFErrors(retval);
-  // Set chunksize to number of time steps, or 1 if time dimension is unlimited
+  // Set the chunksize to the chunksize of the time variable
+  retval = nc_inq_varid(fileid, "time", &time_varid); HandleNetCDFErrors(retval);
+  retval = nc_inq_var_chunking(fileid, time_varid, NULL, &chunksize[0]); HandleNetCDFErrors(retval);
   retval = nc_def_var_chunking(fileid, varid, NC_CHUNKED, chunksize); HandleNetCDFErrors(retval);
 
   // (b) add attributes to variable
@@ -3084,6 +3084,7 @@ int NetCDFAddMetadata2D(const int fileid,const int time_dimid,int nbasins_dimid,
 #ifdef _RVNETCDF_
   int    retval;
   int    dimids2[2];
+  int    time_varid;
   string tmp;
   size_t chunksize2[2];
 
@@ -3098,11 +3099,10 @@ int NetCDFAddMetadata2D(const int fileid,const int time_dimid,int nbasins_dimid,
   // Set compression
   retval = nc_def_var_deflate(fileid, varid, 1, 1, NETCDF_DEFLATE_LEVEL); HandleNetCDFErrors(retval);
   // Set time chunksize to number of time steps
-  retval = nc_inq_var_chunking(fileid, time_dimid, NULL, &chunksize2[0]); HandleNetCDFErrors(retval);
+  retval = nc_inq_varid(fileid, "time", &time_varid); HandleNetCDFErrors(retval);
+  retval = nc_inq_var_chunking(fileid, time_varid, NULL, &chunksize2[0]); HandleNetCDFErrors(retval);
    // Set nbasins chunksize to number ensuring that chunks have approximately 10 MB of data (assuming double precision)
   retval = nc_inq_dimlen(fileid, nbasins_dimid, &chunksize2[1]); HandleNetCDFErrors(retval);
-
-
   chunksize2[1] = max((size_t)1, min(chunksize2[1], (size_t)(NETCDF_CHUNKSIZE_MB * 1024 * 1024 / sizeof(double) / chunksize2[0]))); // Ensure at least one basin per chunk
   // Set chunksize
   retval = nc_def_var_chunking(fileid, varid, NC_CHUNKED, chunksize2); HandleNetCDFErrors(retval);


### PR DESCRIPTION


<!--Please ensure the PR fulfills the following requirements! -->
<!-- If this is your first PR, make sure to add your details to the AUTHORS.rst! -->
### Pull Request Checklist:
- [x] This PR addresses an already opened issue (for bug fixes / features)
    - This PR fixes #87 
- [ ] Tests for the changes have been added (for bug fixes / features)
  - [ ] (If applicable) Documentation has been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

 * Compresses NetCDF standard and custom outputs using the deflate filter. 
 * Chunks NetCDF standard and custom outputs, optimizing for time series analysis (one chunk covers the entire time series). 

Compression is particularly useful with simulations that do not include q_obs. Without compression, we still need to store the full array of NaNs. 

### Does this PR introduce a breaking change?
<!-- If so, please describe the impact and migration path for existing applications -->

 * I ran the RavenPy test suite and no errors were raised. 

### Other information:
<!-- Any other information that is of relevance to this PR, such as screenshots or references to external documentation. -->
